### PR TITLE
Implemented data container widget initial version

### DIFF
--- a/src/FormControl.tsx
+++ b/src/FormControl.tsx
@@ -28,11 +28,18 @@ const FormControlStyled = styled(BaseFormControl)`
   align-items: center;
 `;
 
+const ReadOnlyContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+`;
+
 export interface FormControlOptions {
   control: Control;
   className?: string;
   onScreenDataChange?: (data: Record<string, any>) => void;
   render: (state: FormControlRenderState) => React.ReactNode;
+  renderValue?: (value: string) => React.ReactNode;
 }
 
 export interface FormControlRenderState {
@@ -86,6 +93,27 @@ export const useFormControl = (options: FormControlOptions): React.ReactElement 
       </ExplanationTooltip>
     );
   };
+
+  //@ts-ignore
+  if (control.readOnly) {
+    //@ts-ignore
+    if (control.labelDisplay === "automatic") {
+      //@ts-ignore
+      const label = `${control.label}:`;
+      const renderValue = options.renderValue ?? ((value: string) => value);
+      return (
+        <ReadOnlyContainer>
+          <Typography>{label}</Typography>
+          {/* @ts-ignore */}
+          <Typography>{renderValue(control.value)}</Typography>
+          {renderExplanation()}
+        </ReadOnlyContainer>
+      );
+    } else {
+      //@ts-ignore
+      control.disabled = true;
+    }
+  }
 
   const sxForSeparateLabel =
     "sxForSeparateLabel" in control &&

--- a/src/parts/controls/CurrencyControlWidget.tsx
+++ b/src/parts/controls/CurrencyControlWidget.tsx
@@ -43,6 +43,7 @@ const CurrencyControlWidget = Object.assign(
       control,
       className: className,
       onScreenDataChange: chOnScreenData,
+      renderValue: (value) => `${symbol || "$"} ${value}`,
       render: ({ onChange, forId, value, error, inlineLabel, renderExplanation }) => {
         const typedValue = value as CurrencyControl["value"];
 

--- a/src/parts/controls/DataContainerWidget.tsx
+++ b/src/parts/controls/DataContainerWidget.tsx
@@ -1,0 +1,64 @@
+import type { RenderableControl, RenderableDataContainerControl } from "@decisively-io/interview-sdk";
+import { Typography } from "@material-ui/core";
+import React from "react";
+import { Control } from "react-hook-form";
+import styled from "styled-components";
+import { StyledControlsWrap } from "../Content";
+import type { ControlWidgetProps } from "./ControlWidgetTypes";
+import RenderControl from "./RenderControl";
+import type { ControlComponents } from "./index";
+
+const ColumnWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+`;
+
+export interface DataContainerControlWidgetProps extends ControlWidgetProps<RenderableDataContainerControl> {
+  controlComponents: ControlComponents;
+}
+
+const DataContainerControlWidget = (props: DataContainerControlWidgetProps) => {
+  const { control, controlComponents } = props;
+
+  const colNr = control.columns;
+  const controls = control.controls ?? [];
+
+  // const colData = (new Array(colNr)).fill(new Array()) as RenderableControl[][];
+  const colData = [] as RenderableControl[][];
+  for (let i = 0; i < colNr; i++) {
+    colData.push([]);
+  }
+  for (let i = 0; i < controls.length; i++) {
+    const col = i % colNr;
+    colData[col].push(controls[i]);
+  }
+
+  return (
+    <>
+      {control.label ? <Typography variant="h5">{control.label}</Typography> : null}
+      <ColumnWrapper>
+        {colData.map((col, colIndex) => {
+          return (
+            <StyledControlsWrap
+              data-id={control}
+              data-loading={(control as any).loading ? "true" : undefined}
+              key={colIndex}
+            >
+              {col.map((value, controlIndex) => {
+                return (
+                  <RenderControl
+                    key={controlIndex}
+                    control={value}
+                    controlComponents={controlComponents}
+                  />
+                );
+              })}
+            </StyledControlsWrap>
+          );
+        })}
+      </ColumnWrapper>
+    </>
+  );
+};
+
+export default DataContainerControlWidget;

--- a/src/parts/controls/RenderControl.tsx
+++ b/src/parts/controls/RenderControl.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import type { ControlWidgetProps } from "./ControlWidgetTypes";
 import type { ControlComponents } from "./index";
 
-const NAME_MAP: Omit<Record<RenderableControlType, keyof ControlComponents>, "data_container" | "file" | "document"> = {
+const NAME_MAP: Omit<Record<RenderableControlType, keyof ControlComponents>, "file" | "document"> = {
   boolean: "Boolean",
   currency: "Currency",
   date: "Date",
@@ -18,6 +18,7 @@ const NAME_MAP: Omit<Record<RenderableControlType, keyof ControlComponents>, "da
   switch_container: "SwitchContainer",
   certainty_container: "CertaintyContainer",
   repeating_container: "RepeatingContainer",
+  data_container: "DataContainer",
 };
 
 export interface RenderControlProps extends ControlWidgetProps<Control> {

--- a/src/parts/controls/TextControlWidget.tsx
+++ b/src/parts/controls/TextControlWidget.tsx
@@ -66,6 +66,7 @@ const TextControlWidget = Object.assign(
               error: error !== undefined,
               helperText: error?.message || " ",
               disabled: control.disabled,
+              inputProps: { readOnly: control.readOnly },
               ...maybeWithType,
               ...maybeWithMulti,
               ...textFieldProps,

--- a/src/parts/controls/TextControlWidget.tsx
+++ b/src/parts/controls/TextControlWidget.tsx
@@ -66,7 +66,6 @@ const TextControlWidget = Object.assign(
               error: error !== undefined,
               helperText: error?.message || " ",
               disabled: control.disabled,
-              inputProps: { readOnly: control.readOnly },
               ...maybeWithType,
               ...maybeWithMulti,
               ...textFieldProps,

--- a/src/parts/controls/TimeControlWidget.tsx
+++ b/src/parts/controls/TimeControlWidget.tsx
@@ -33,6 +33,7 @@ const TimeControlWidget = Object.assign(
       control,
       className: className,
       onScreenDataChange: chOnScreenData,
+      // renderValue: (value) => `${value}`, // TODO: figure out how to convert 24 hour time to am/pm format if amPmFormat is ture
       render: ({ onChange, value, error, forId, inlineLabel, renderExplanation }) => {
         const typedValue = value as TimeControl["value"];
         const compValue = typeof typedValue === "string" ? new Date(`1970-01-01T${value}`) : null;

--- a/src/parts/controls/index.tsx
+++ b/src/parts/controls/index.tsx
@@ -5,6 +5,7 @@ import type { Control } from "@decisively-io/interview-sdk";
 import BooleanControlWidget, { type BooleanControlWidgetProps } from "./BooleanControlWidget";
 import CertaintyContainerWidget, { type CertaintyContainerControlWidgetProps } from "./CertaintyContainerWidget";
 import CurrencyControlWidget, { type CurrencyControlWidgetProps } from "./CurrencyControlWidget";
+import DataContainerWidget, { type DataContainerControlWidgetProps } from "./DataContainerWidget";
 import DateControlWidget, { type DateControlWidgetProps } from "./DateControlWidget";
 import DateTimeControlWidget, { type DateTimeControlWidgetProps } from "./DateTimeControlWidget";
 import EntityControlWidget, { type EntityControlWidgetProps } from "./EntityControlWidget";
@@ -41,6 +42,7 @@ export interface ControlComponents {
   SwitchContainer?: React.ComponentType<SwitchContainerControlWidgetProps>;
   CertaintyContainer?: React.ComponentType<CertaintyContainerControlWidgetProps>;
   RepeatingContainer?: React.ComponentType<RepeatingContainerControlWidgetProps>;
+  DataContainer?: React.ComponentType<DataContainerControlWidgetProps>;
 }
 
 const DEFAULT_CONTROL_COMPONENTS: ControlComponents = {
@@ -58,6 +60,7 @@ const DEFAULT_CONTROL_COMPONENTS: ControlComponents = {
   SwitchContainer: SwitchContainerWidget,
   CertaintyContainer: CertaintyContainerWidget,
   RepeatingContainer: RepeatingContainerWidget,
+  DataContainer: DataContainerWidget,
 };
 
 const Controls = React.memo((props: ControlsProps) => {


### PR DESCRIPTION
- In FormControl added a check if the control is readOnly and if so render it as read only.
- For read only I treated the labelDisplay === 'automatic' as the method for displaying just the label and value as text in the format `{label}: {value}`. If the user specifies inline or separate then it will render the input control but disable it so the user can't edit. We should consider adding another option to labelDisplay that is specific for the Read Only display that doesn't use the input component but only renders text.
- For read only values rendered as text we would also want to style the label text differently from the value text, with the label text being a lighter shade of gray.
- Added DataContainerWidget. It will need some further styling, such as proper spacing of the columns, and maybe a review of my column rendering strategy, maybe there is a better way?